### PR TITLE
Fix optional arguments doc for Model.findOne

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -1012,10 +1012,10 @@ Model.findById = function findById (id, fields, options, callback) {
  *     // chaining findOne queries (same as above)
  *     Adventure.findOne({ type: 'iphone' }).select('name').lean().exec(callback);
  *
- * @param {Object} conditions
+ * @param {Object} [conditions]
  * @param {Object} [fields] optional fields to select
  * @param {Object} [options] optional
- * @param {Function} [callback]
+ * @param {Function} callback
  * @return {Query}
  * @see field selection #query_Query-select
  * @see lean queries #query_Query-lean


### PR DESCRIPTION
In the documentation for Model.findOne, the argument 'conditions' is not marked as optional, and argument 'callback' is marked.
However, the code clearly shows it's in the other way around.