### PR TITLE
Add DTrace to mongoose queries

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -13,6 +13,7 @@ var url = require('url')
   , MongooseError = require('./error')
   , assert =require('assert')
   , muri = require('muri')
+  , dtrace = require('./dtrace')  
 
 /*!
  * Protocol prefix regexp.
@@ -247,6 +248,11 @@ Connection.prototype.open = function (host, database, port, options, callback) {
   this.name = database;
   this.host = host;
   this.port = port;
+
+  // Init DTrace if enabled
+  if (this.base.options.dtrace) {
+      dtrace.init();
+  }
 
   this._open(callback);
   return this;

--- a/lib/dtrace.js
+++ b/lib/dtrace.js
@@ -1,14 +1,9 @@
 // DTrace
 var dtrace = require('dtrace-provider');
-var dtraceProvider = dtrace.createDTraceProvider("mongoose");
-exports.dtraceProvider = dtraceProvider;
-
-dtraceProvider.addProbe("query-start","char *", "char *", "int");
-dtraceProvider.addProbe("query-done", "char *", "char *", "int");
-dtraceProvider.enable();
 
 var MAX_INT = Math.pow(2, 32) - 1;
 var DTRACE_ID = 0;
+exports.enabled = false;
 
 exports.nextDTraceID = function() {
     if (++DTRACE_ID >= MAX_INT) {
@@ -17,3 +12,15 @@ exports.nextDTraceID = function() {
 
     return (DTRACE_ID);
 };
+
+
+exports.init = function() {
+    var dtraceProvider = dtrace.createDTraceProvider("mongoose");
+    exports.dtraceProvider = dtraceProvider;
+
+    dtraceProvider.addProbe("query-start","char *", "char *", "int");
+    dtraceProvider.addProbe("query-done", "char *", "char *", "int");
+    dtraceProvider.enable();
+    exports.enabled = true;
+}
+

--- a/lib/dtrace.js
+++ b/lib/dtrace.js
@@ -1,0 +1,19 @@
+// DTrace
+var dtrace = require('dtrace-provider');
+var dtraceProvider = dtrace.createDTraceProvider("mongoose");
+exports.dtraceProvider = dtraceProvider;
+
+var queryProbe = dtraceProvider.addProbe("query-start", "char *", "int");
+var queryProbe = dtraceProvider.addProbe("query-done", "char *", "int");
+dtraceProvider.enable();
+
+var MAX_INT = Math.pow(2, 32) - 1;
+var DTRACE_ID = 0;
+
+exports.nextDTraceID = function() {
+    if (++DTRACE_ID >= MAX_INT) {
+                DTRACE_ID = 1;
+    }
+
+    return (DTRACE_ID);
+};

--- a/lib/dtrace.js
+++ b/lib/dtrace.js
@@ -3,8 +3,8 @@ var dtrace = require('dtrace-provider');
 var dtraceProvider = dtrace.createDTraceProvider("mongoose");
 exports.dtraceProvider = dtraceProvider;
 
-var queryProbe = dtraceProvider.addProbe("query-start", "char *", "int");
-var queryProbe = dtraceProvider.addProbe("query-done", "char *", "int");
+dtraceProvider.addProbe("query-start", "char *", "int");
+dtraceProvider.addProbe("query-done", "char *", "int");
 dtraceProvider.enable();
 
 var MAX_INT = Math.pow(2, 32) - 1;

--- a/lib/dtrace.js
+++ b/lib/dtrace.js
@@ -3,8 +3,8 @@ var dtrace = require('dtrace-provider');
 var dtraceProvider = dtrace.createDTraceProvider("mongoose");
 exports.dtraceProvider = dtraceProvider;
 
-dtraceProvider.addProbe("query-start", "char *", "int");
-dtraceProvider.addProbe("query-done", "char *", "int");
+dtraceProvider.addProbe("query-start","char *", "char *", "int");
+dtraceProvider.addProbe("query-done", "char *", "char *", "int");
 dtraceProvider.enable();
 
 var MAX_INT = Math.pow(2, 32) - 1;

--- a/lib/model.js
+++ b/lib/model.js
@@ -132,7 +132,7 @@ function handleSave (promise, queryId, self) {
 
 
     dtrace.dtraceProvider.fire("query-done", function(p) { 
-        return ["save", queryId];
+        return [modelName, "save", queryId];
     });
     self.emit('save', self, numAffected);
     promise.complete(self, numAffected);
@@ -171,8 +171,9 @@ function handleSave (promise, queryId, self) {
 
 Model.prototype.save = function save (fn) {
   var queryId = dtrace.nextDTraceID();
+  var modelName = this.modelName;
   dtrace.dtraceProvider.fire("query-start", function(p) { 
-    return ["save", queryId];
+    return [modelName, "save", queryId];
   });
   var promise = new Promise(fn)
     , complete = handleSave(promise, queryId, this)

--- a/lib/model.js
+++ b/lib/model.js
@@ -84,7 +84,7 @@ Model.prototype.modelName;
  * Handles doc.save() callbacks
  */
 
-function handleSave (promise, queryId, self) {
+function handleSave (promise, modelName, queryId, self) {
   return tick(function handleSave (err, result) {
     if (err) {
       // If the initial insert fails provide a second chance.
@@ -176,7 +176,7 @@ Model.prototype.save = function save (fn) {
     return [modelName, "save", queryId];
   });
   var promise = new Promise(fn)
-    , complete = handleSave(promise, queryId, this)
+    , complete = handleSave(promise, modelName, queryId, this)
     , options = {}
 
   if (this.schema.options.safe) {

--- a/lib/model.js
+++ b/lib/model.js
@@ -22,6 +22,7 @@ var Document = require('./document')
   , util = require('util')
   , tick = utils.tick
   , Query = require('./query.js')
+  , dtrace = require('./dtrace')
 
 var VERSION_WHERE = 1
   , VERSION_INC = 2
@@ -83,7 +84,7 @@ Model.prototype.modelName;
  * Handles doc.save() callbacks
  */
 
-function handleSave (promise, self) {
+function handleSave (promise, queryId, self) {
   return tick(function handleSave (err, result) {
     if (err) {
       // If the initial insert fails provide a second chance.
@@ -129,6 +130,10 @@ function handleSave (promise, self) {
       }
     }
 
+
+    dtrace.dtraceProvider.fire("query-done", function(p) { 
+        return ["save", queryId];
+    });
     self.emit('save', self, numAffected);
     promise.complete(self, numAffected);
     promise = self = null;
@@ -165,8 +170,12 @@ function handleSave (promise, self) {
  */
 
 Model.prototype.save = function save (fn) {
+  var queryId = dtrace.nextDTraceID();
+  dtrace.dtraceProvider.fire("query-start", function(p) { 
+    return ["save", queryId];
+  });
   var promise = new Promise(fn)
-    , complete = handleSave(promise, this)
+    , complete = handleSave(promise, queryId, this)
     , options = {}
 
   if (this.schema.options.safe) {

--- a/lib/model.js
+++ b/lib/model.js
@@ -171,7 +171,7 @@ function handleSave (promise, modelName, queryId, self) {
 
 Model.prototype.save = function save (fn) {
   var queryId = dtrace.nextDTraceID();
-  var modelName = this.modelName;
+  var modelName = this.collection.name;
   dtrace.dtraceProvider.fire("query-start", function(p) { 
     return [modelName, "save", queryId];
   });

--- a/lib/model.js
+++ b/lib/model.js
@@ -131,9 +131,11 @@ function handleSave (promise, modelName, queryId, self) {
     }
 
 
-    dtrace.dtraceProvider.fire("query-done", function(p) { 
-        return [modelName, "save", queryId];
-    });
+    if (dtrace.enabled) {
+        dtrace.dtraceProvider.fire("query-done", function(p) { 
+            return [modelName, "save", queryId];
+        });
+    }
     self.emit('save', self, numAffected);
     promise.complete(self, numAffected);
     promise = self = null;
@@ -170,11 +172,15 @@ function handleSave (promise, modelName, queryId, self) {
  */
 
 Model.prototype.save = function save (fn) {
-  var queryId = dtrace.nextDTraceID();
+  var queryId = null;
   var modelName = this.collection.name;
-  dtrace.dtraceProvider.fire("query-start", function(p) { 
-    return [modelName, "save", queryId];
-  });
+  
+  if (dtrace.enabled) {
+      queryId = dtrace.nextDTraceID();
+      dtrace.dtraceProvider.fire("query-start", function(p) { 
+        return [modelName, "save", queryId];
+      });
+  }
   var promise = new Promise(fn)
     , complete = handleSave(promise, modelName, queryId, this)
     , options = {}

--- a/lib/query.js
+++ b/lib/query.js
@@ -1685,6 +1685,11 @@ function convertSortToArray (opts) {
  */
 
 Query.prototype.update = function (conditions, doc, options, callback) {
+  var queryId = dtrace.nextDTraceID();
+  dtrace.dtraceProvider.fire("query-start", function(p) { 
+    return ["update", queryId];
+  });
+
   if ('function' === typeof options) {
     // Scenario: update(conditions, doc, callback)
     callback = options;
@@ -1756,7 +1761,18 @@ Query.prototype.update = function (conditions, doc, options, callback) {
     return this;
   }
 
-  return Query.base.update.call(this, castedQuery, castedDoc, options, callback);
+  return Query.base.update.call(
+    this,
+    castedQuery,
+    castedDoc,
+    options, 
+    function cb(err, numAffected) {
+      dtrace.dtraceProvider.fire("query-done", function(p) { 
+        return ["update", queryId];
+      });
+      callback(err, numAffected);
+    }
+  );
 }
 
 /**

--- a/lib/query.js
+++ b/lib/query.js
@@ -1516,6 +1516,11 @@ Query.prototype._findAndModify = function (type, callback) {
     throw new Error("Expected callback in _findAndModify");
   }
 
+  var queryId = nextDTraceID();
+  dtraceProvider.fire("query-start", function(p) { 
+    return ["findAndModify", queryId];
+  });
+
   var model = this.model
     , promise = new Promise(callback)
     , self = this
@@ -1579,6 +1584,9 @@ Query.prototype._findAndModify = function (type, callback) {
     }
 
     if (!options.populate) {
+      dtraceProvider.fire("query-done", function(p) { 
+        return ["findAndModify", queryId];
+      });
       return true === options.lean
         ? promise.complete(doc)
         : completeOne(self.model, doc, fields, self, null, promise);
@@ -1588,6 +1596,9 @@ Query.prototype._findAndModify = function (type, callback) {
     self.model.populate(doc, pop, function (err, doc) {
       if (err) return promise.error(err);
 
+      dtraceProvider.fire("query-done", function(p) { 
+        return ["findAndModify", queryId];
+      });
       return true === options.lean
         ? promise.complete(doc)
         : completeOne(self.model, doc, fields, self, pop, promise);

--- a/lib/query.js
+++ b/lib/query.js
@@ -1820,6 +1820,23 @@ Query.prototype.exec = function exec (op, callback) {
     this.op = op;
   }
 
+  if (dtrace.enabled) {
+      var modelName = this.model.modelName;
+      var queryOp = this.op;
+      var queryId = dtrace.nextDTraceID();
+
+      dtrace.dtraceProvider.fire("query-start", function(p) { 
+        return [modelName, queryOp, queryId];
+      });
+      promise.addBack(function(err, doc) {
+          if (!err) {
+              dtrace.dtraceProvider.fire("query-done", function(p) { 
+                  return [modelName, queryOp, queryId];
+              });
+          }
+      });
+  }
+
   if (callback) promise.addBack(callback);
 
   if (!this.op) {

--- a/lib/query.js
+++ b/lib/query.js
@@ -13,25 +13,8 @@ var helpers = require('./queryhelpers');
 var Types = require('./schema/index');
 var Document = require('./document');
 var QueryStream = require('./querystream');
+var dtrace = require('./dtrace');
 
-// DTrace
-var dtrace = require('dtrace-provider');
-var dtraceProvider = dtrace.createDTraceProvider("mongoose");
-
-var queryProbe = dtraceProvider.addProbe("query-start", "char *", "int");
-var queryProbe = dtraceProvider.addProbe("query-done", "char *", "int");
-dtraceProvider.enable();
-
-var MAX_INT = Math.pow(2, 32) - 1;
-var DTRACE_ID = 0;
-
-function nextDTraceID() {
-    if (++DTRACE_ID >= MAX_INT) {
-                DTRACE_ID = 1;
-    }
-
-    return (DTRACE_ID);
-};
 
 /**
  * Query constructor used for building queries.
@@ -1096,8 +1079,8 @@ function completeMany (model, docs, fields, self, pop, promise) {
  */
 
 Query.prototype.findOne = function (conditions, fields, options, callback) {
-  var queryId = nextDTraceID();
-  dtraceProvider.fire("query-start", function(p) { 
+  var queryId = dtrace.nextDTraceID();
+  dtrace.dtraceProvider.fire("query-start", function(p) { 
     return ["findOne", queryId];
   });
 
@@ -1170,7 +1153,7 @@ Query.prototype.findOne = function (conditions, fields, options, callback) {
     if (!doc) return promise.complete(null);
 
     if (!options.populate) {
-      dtraceProvider.fire("query-done", function(p) { 
+      dtrace.dtraceProvider.fire("query-done", function(p) { 
         return ["findOne", queryId];
       });
       return true === options.lean
@@ -1182,7 +1165,7 @@ Query.prototype.findOne = function (conditions, fields, options, callback) {
     self.model.populate(doc, pop, function (err, doc) {
       if (err) return promise.error(err);
 
-      dtraceProvider.fire("query-done", function(p) { 
+      dtrace.dtraceProvider.fire("query-done", function(p) { 
         return ["findOne", queryId];
       });
 
@@ -1516,8 +1499,8 @@ Query.prototype._findAndModify = function (type, callback) {
     throw new Error("Expected callback in _findAndModify");
   }
 
-  var queryId = nextDTraceID();
-  dtraceProvider.fire("query-start", function(p) { 
+  var queryId = dtrace.nextDTraceID();
+  dtrace.dtraceProvider.fire("query-start", function(p) { 
     return ["findAndModify", queryId];
   });
 
@@ -1584,7 +1567,7 @@ Query.prototype._findAndModify = function (type, callback) {
     }
 
     if (!options.populate) {
-      dtraceProvider.fire("query-done", function(p) { 
+      dtrace.dtraceProvider.fire("query-done", function(p) { 
         return ["findAndModify", queryId];
       });
       return true === options.lean
@@ -1596,7 +1579,7 @@ Query.prototype._findAndModify = function (type, callback) {
     self.model.populate(doc, pop, function (err, doc) {
       if (err) return promise.error(err);
 
-      dtraceProvider.fire("query-done", function(p) { 
+      dtrace.dtraceProvider.fire("query-done", function(p) { 
         return ["findAndModify", queryId];
       });
       return true === options.lean

--- a/lib/query.js
+++ b/lib/query.js
@@ -14,6 +14,25 @@ var Types = require('./schema/index');
 var Document = require('./document');
 var QueryStream = require('./querystream');
 
+// DTrace
+var dtrace = require('dtrace-provider');
+var dtraceProvider = dtrace.createDTraceProvider("mongoose");
+
+var queryProbe = dtraceProvider.addProbe("query-start", "char *", "int");
+var queryProbe = dtraceProvider.addProbe("query-done", "char *", "int");
+dtraceProvider.enable();
+
+var MAX_INT = Math.pow(2, 32) - 1;
+var DTRACE_ID = 0;
+
+function nextDTraceID() {
+    if (++DTRACE_ID >= MAX_INT) {
+                DTRACE_ID = 1;
+    }
+
+    return (DTRACE_ID);
+};
+
 /**
  * Query constructor used for building queries.
  *
@@ -1077,6 +1096,11 @@ function completeMany (model, docs, fields, self, pop, promise) {
  */
 
 Query.prototype.findOne = function (conditions, fields, options, callback) {
+  var queryId = nextDTraceID();
+  dtraceProvider.fire("query-start", function(p) { 
+    return ["findOne", queryId];
+  });
+
   if ('function' == typeof conditions) {
     callback = conditions;
     conditions = null;
@@ -1146,6 +1170,9 @@ Query.prototype.findOne = function (conditions, fields, options, callback) {
     if (!doc) return promise.complete(null);
 
     if (!options.populate) {
+      dtraceProvider.fire("query-done", function(p) { 
+        return ["findOne", queryId];
+      });
       return true === options.lean
         ? promise.complete(doc)
         : completeOne(self.model, doc, fields, self, null, promise);
@@ -1154,6 +1181,10 @@ Query.prototype.findOne = function (conditions, fields, options, callback) {
     var pop = helpers.preparePopulationOptionsMQ(self, options);
     self.model.populate(doc, pop, function (err, doc) {
       if (err) return promise.error(err);
+
+      dtraceProvider.fire("query-done", function(p) { 
+        return ["findOne", queryId];
+      });
 
       return true === options.lean
         ? promise.complete(doc)

--- a/lib/query.js
+++ b/lib/query.js
@@ -1079,11 +1079,14 @@ function completeMany (model, docs, fields, self, pop, promise) {
  */
 
 Query.prototype.findOne = function (conditions, fields, options, callback) {
-  var queryId = dtrace.nextDTraceID();
+  var queryId = null;
   var modelName = this.model.modelName;
-  dtrace.dtraceProvider.fire("query-start", function(p) { 
-    return [modelName, "findOne", queryId];
-  });
+  if (dtrace.enabled) {
+      queryId = dtrace.nextDTraceID();
+      dtrace.dtraceProvider.fire("query-start", function(p) { 
+        return [modelName, "findOne", queryId];
+      });
+  }
 
   if ('function' == typeof conditions) {
     callback = conditions;
@@ -1154,9 +1157,11 @@ Query.prototype.findOne = function (conditions, fields, options, callback) {
     if (!doc) return promise.complete(null);
 
     if (!options.populate) {
-      dtrace.dtraceProvider.fire("query-done", function(p) { 
-        return [modelName, "findOne", queryId];
-      });
+      if (dtrace.enabled) {
+          dtrace.dtraceProvider.fire("query-done", function(p) { 
+              return [modelName, "findOne", queryId];
+          });
+      }
       return true === options.lean
         ? promise.complete(doc)
         : completeOne(self.model, doc, fields, self, null, promise);
@@ -1166,10 +1171,11 @@ Query.prototype.findOne = function (conditions, fields, options, callback) {
     self.model.populate(doc, pop, function (err, doc) {
       if (err) return promise.error(err);
 
-      dtrace.dtraceProvider.fire("query-done", function(p) { 
-        return [modelName, "findOne", queryId];
-      });
-
+      if (dtrace.enabled) {
+          dtrace.dtraceProvider.fire("query-done", function(p) { 
+            return [modelName, "findOne", queryId];
+          });
+      }
       return true === options.lean
         ? promise.complete(doc)
         : completeOne(self.model, doc, fields, self, pop, promise);
@@ -1499,13 +1505,14 @@ Query.prototype._findAndModify = function (type, callback) {
   if ('function' != typeof callback) {
     throw new Error("Expected callback in _findAndModify");
   }
-
-  var queryId = dtrace.nextDTraceID();
+  var queryId = null;
   var modelName = this.model.modelName;
-  dtrace.dtraceProvider.fire("query-start", function(p) { 
-    return [modelName, "findAndModify", queryId];
-  });
-
+  if (dtrace.enabled) {
+      queryId = dtrace.nextDTraceID();
+      dtrace.dtraceProvider.fire("query-start", function(p) { 
+        return [modelName, "findAndModify", queryId];
+      });
+  }
   var model = this.model
     , promise = new Promise(callback)
     , self = this
@@ -1569,9 +1576,11 @@ Query.prototype._findAndModify = function (type, callback) {
     }
 
     if (!options.populate) {
-      dtrace.dtraceProvider.fire("query-done", function(p) { 
-        return [modelName, "findAndModify", queryId];
-      });
+      if (dtrace.enabled) {
+          dtrace.dtraceProvider.fire("query-done", function(p) { 
+            return [modelName, "findAndModify", queryId];
+          });
+      }
       return true === options.lean
         ? promise.complete(doc)
         : completeOne(self.model, doc, fields, self, null, promise);
@@ -1581,9 +1590,11 @@ Query.prototype._findAndModify = function (type, callback) {
     self.model.populate(doc, pop, function (err, doc) {
       if (err) return promise.error(err);
 
-      dtrace.dtraceProvider.fire("query-done", function(p) { 
-        return [modelName, "findAndModify", queryId];
-      });
+      if (dtrace.enabled) {
+          dtrace.dtraceProvider.fire("query-done", function(p) { 
+            return [modelName, "findAndModify", queryId];
+          });
+      }
       return true === options.lean
         ? promise.complete(doc)
         : completeOne(self.model, doc, fields, self, pop, promise);
@@ -1687,12 +1698,14 @@ function convertSortToArray (opts) {
  */
 
 Query.prototype.update = function (conditions, doc, options, callback) {
-  var queryId = dtrace.nextDTraceID();
+  var queryId = null;
   var modelName = this.model.modelName;
-  dtrace.dtraceProvider.fire("query-start", function(p) { 
-    return [modelName, "update", queryId];
-  });
-
+  if (dtrace.enabled) {
+      var queryId = dtrace.nextDTraceID();
+      dtrace.dtraceProvider.fire("query-start", function(p) { 
+        return [modelName, "update", queryId];
+      });
+  }
   if ('function' === typeof options) {
     // Scenario: update(conditions, doc, callback)
     callback = options;
@@ -1770,9 +1783,11 @@ Query.prototype.update = function (conditions, doc, options, callback) {
     castedDoc,
     options, 
     function cb(err, numAffected) {
-      dtrace.dtraceProvider.fire("query-done", function(p) { 
-        return [modelName, "update", queryId];
-      });
+      if (dtrace.enabled) {
+          dtrace.dtraceProvider.fire("query-done", function(p) { 
+            return [modelName, "update", queryId];
+          });
+      }
       callback(err, numAffected);
     }
   );

--- a/lib/query.js
+++ b/lib/query.js
@@ -1080,8 +1080,9 @@ function completeMany (model, docs, fields, self, pop, promise) {
 
 Query.prototype.findOne = function (conditions, fields, options, callback) {
   var queryId = dtrace.nextDTraceID();
+  var modelName = this.model.modelName;
   dtrace.dtraceProvider.fire("query-start", function(p) { 
-    return ["findOne", queryId];
+    return [modelName, "findOne", queryId];
   });
 
   if ('function' == typeof conditions) {
@@ -1154,7 +1155,7 @@ Query.prototype.findOne = function (conditions, fields, options, callback) {
 
     if (!options.populate) {
       dtrace.dtraceProvider.fire("query-done", function(p) { 
-        return ["findOne", queryId];
+        return [modelName, "findOne", queryId];
       });
       return true === options.lean
         ? promise.complete(doc)
@@ -1166,7 +1167,7 @@ Query.prototype.findOne = function (conditions, fields, options, callback) {
       if (err) return promise.error(err);
 
       dtrace.dtraceProvider.fire("query-done", function(p) { 
-        return ["findOne", queryId];
+        return [modelName, "findOne", queryId];
       });
 
       return true === options.lean
@@ -1500,8 +1501,9 @@ Query.prototype._findAndModify = function (type, callback) {
   }
 
   var queryId = dtrace.nextDTraceID();
+  var modelName = this.model.modelName;
   dtrace.dtraceProvider.fire("query-start", function(p) { 
-    return ["findAndModify", queryId];
+    return [modelName, "findAndModify", queryId];
   });
 
   var model = this.model
@@ -1568,7 +1570,7 @@ Query.prototype._findAndModify = function (type, callback) {
 
     if (!options.populate) {
       dtrace.dtraceProvider.fire("query-done", function(p) { 
-        return ["findAndModify", queryId];
+        return [modelName, "findAndModify", queryId];
       });
       return true === options.lean
         ? promise.complete(doc)
@@ -1580,7 +1582,7 @@ Query.prototype._findAndModify = function (type, callback) {
       if (err) return promise.error(err);
 
       dtrace.dtraceProvider.fire("query-done", function(p) { 
-        return ["findAndModify", queryId];
+        return [modelName, "findAndModify", queryId];
       });
       return true === options.lean
         ? promise.complete(doc)
@@ -1686,8 +1688,9 @@ function convertSortToArray (opts) {
 
 Query.prototype.update = function (conditions, doc, options, callback) {
   var queryId = dtrace.nextDTraceID();
+  var modelName = this.model.modelName;
   dtrace.dtraceProvider.fire("query-start", function(p) { 
-    return ["update", queryId];
+    return [modelName, "update", queryId];
   });
 
   if ('function' === typeof options) {
@@ -1768,7 +1771,7 @@ Query.prototype.update = function (conditions, doc, options, callback) {
     options, 
     function cb(err, numAffected) {
       dtrace.dtraceProvider.fire("query-done", function(p) { 
-        return ["update", queryId];
+        return [modelName, "update", queryId];
       });
       callback(err, numAffected);
     }

--- a/package.json
+++ b/package.json
@@ -1,44 +1,64 @@
 {
-    "name": "mongoose"
-  , "description": "Mongoose MongoDB ODM"
-  , "version": "3.8.9-pre"
-  , "author": "Guillermo Rauch <guillermo@learnboost.com>"
-  , "keywords": ["mongodb", "document", "model", "schema", "database", "odm", "data", "datastore", "query", "nosql", "orm", "db"]
-  , "dependencies": {
-        "hooks": "0.2.1"
-      , "mongodb": "1.4.3"
-      , "ms": "0.1.0"
-      , "sliced": "0.0.5"
-      , "muri": "0.3.1"
-      , "mpromise": "0.4.3"
-      , "mpath": "0.1.1"
-      , "regexp-clone": "0.0.1"
-      , "mquery" : "0.7.0"
-    }
-  , "devDependencies": {
-        "mocha": "1.12.0"
-      , "node-static": "0.5.9"
-      , "dox": "0.3.1"
-      , "jade": "0.26.3"
-      , "highlight.js": "7.0.1"
-      , "markdown": "0.3.1"
-      , "promises-aplus-tests": ">= 1.0.2"
-      , "tbd": "0.6.4"
-      , "benchmark" : "1.0.0"
-      , "open": "0.0.3"
-      , "async": "0.2.5"
-    }
-  , "directories": { "lib": "./lib/mongoose" }
-  , "scripts": { "test": "make test" }
-  , "main": "./index.js"
-  , "engines": { "node": ">=0.6.19" }
-  , "bugs": {
-        "url":"https://github.com/learnboost/mongoose/issues/new"
-      , "email": "mongoose-orm@googlegroups.com"
-    }
-  , "repository": {
-        "type": "git"
-      , "url": "git://github.com/LearnBoost/mongoose.git"
-    }
-  , "homepage": "http://mongoosejs.com"
+  "name": "mongoose",
+  "description": "Mongoose MongoDB ODM",
+  "version": "3.8.9-pre",
+  "author": "Guillermo Rauch <guillermo@learnboost.com>",
+  "keywords": [
+    "mongodb",
+    "document",
+    "model",
+    "schema",
+    "database",
+    "odm",
+    "data",
+    "datastore",
+    "query",
+    "nosql",
+    "orm",
+    "db"
+  ],
+  "dependencies": {
+    "hooks": "0.2.1",
+    "mongodb": "1.4.3",
+    "ms": "0.1.0",
+    "sliced": "0.0.5",
+    "muri": "0.3.1",
+    "mpromise": "0.4.3",
+    "mpath": "0.1.1",
+    "regexp-clone": "0.0.1",
+    "mquery": "0.7.0",
+    "dtrace-provider": "~0.2.8"
+  },
+  "devDependencies": {
+    "mocha": "1.12.0",
+    "node-static": "0.5.9",
+    "dox": "0.3.1",
+    "jade": "0.26.3",
+    "highlight.js": "7.0.1",
+    "markdown": "0.3.1",
+    "promises-aplus-tests": ">= 1.0.2",
+    "tbd": "0.6.4",
+    "benchmark": "1.0.0",
+    "open": "0.0.3",
+    "async": "0.2.5"
+  },
+  "directories": {
+    "lib": "./lib/mongoose"
+  },
+  "scripts": {
+    "test": "make test"
+  },
+  "main": "./index.js",
+  "engines": {
+    "node": ">=0.6.19"
+  },
+  "bugs": {
+    "url": "https://github.com/learnboost/mongoose/issues/new",
+    "email": "mongoose-orm@googlegroups.com"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/LearnBoost/mongoose.git"
+  },
+  "homepage": "http://mongoosejs.com"
 }


### PR DESCRIPTION
Hi!
I was wondering if you can review my attempt to add DTrace probes to mongoose queries.
Inspired by the node-restify DTrace probes, I tried to add probing at key query functions in mongoose so I can profile my DB queries.
I'm using the following DTrace script to track both mongoose and restify to profile my server:

```
#!/usr/sbin/dtrace -s
#pragma D option quiet
#pragma D option dynvarsize=128m

restify*:::route-start
{
track[arg2] = timestamp;
}

restify*:::handler-start
/track[arg3]/
{
h[arg3, copyinstr(arg2)] = timestamp;
}

restify*:::handler-done
/track[arg3] && h[arg3, copyinstr(arg2)]/
{
@[copyinstr(arg2)] = quantize((timestamp - h[arg3, copyinstr(arg2)]) / 1000000);
h[arg3, copyinstr(arg2)] = 0;
}

restify*:::route-done
/track[arg2]/
{
@[copyinstr(arg1)] = quantize((timestamp - track[arg2]) / 1000000);
track[arg2] = 0;
}

mongoose*:::query-start
{
mongotrack[arg2] = timestamp;
}

mongoose*:::query-done
/mongotrack[arg2]/
{
@[strjoin(strjoin(copyinstr(arg0),"-"),copyinstr(arg1))] = quantize((timestamp - mongotrack[arg2]) / 1000000);
mongotrack[arg2] = 0;
}
```
The output show a histogram of the execution time of queries such as -
{modelName}-save
{modelName}-findOne
{modelName}-update
 
etc

Thank you!
 
 - Avner
