### PR TITLE
Modified Model.geoNear to support passing either a geoJSON point, or a legacy coordinate pair, to the native driver

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -1765,7 +1765,7 @@ Model.geoNear = function (near, options, callback) {
     return promise;
   }
 
-  var x,y;
+  var x,y,point;
 
   if (Array.isArray(near)) {
     if (near.length != 2) {
@@ -1780,12 +1780,10 @@ Model.geoNear = function (near, options, callback) {
       return promise;
     }
 
-    x = near.coordinates[0];
-    y = near.coordinates[1];
+    point = near;
   }
 
-  var self = this;
-  this.collection.geoNear(x, y, options, function (err, res) {
+  function cb(err, res) {
     if (err) return promise.error(err);
     if (options.lean) return promise.fulfill(res.results, res.stats);
 
@@ -1807,7 +1805,15 @@ Model.geoNear = function (near, options, callback) {
         --count || promise.fulfill(res.results, res.stats);
       });
     }
-  });
+  }
+
+  var self = this
+    , args = [options, cb];
+
+  //call the driver with either the geoJSON point, or the legacy coordinates pair
+  args.unshift.apply(args, point ? [point] : [x, y]);
+  this.collection.geoNear.apply(this.collection, args);
+
   return promise;
 };
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   , "author": "Guillermo Rauch <guillermo@learnboost.com>"
   , "keywords": ["mongodb", "document", "model", "schema", "database", "odm", "data", "datastore", "query", "nosql", "orm", "db"]
   , "dependencies": {
-        "mongodb": "1.4.7"
+        "mongodb": "1.4.8"
       , "hooks": "0.2.1"
       , "ms": "0.1.0"
       , "sliced": "0.0.5"

--- a/test/model.geonear.test.js
+++ b/test/model.geonear.test.js
@@ -29,6 +29,7 @@ describe('model', function(){
       done();
     })
   })
+
   describe('geoNear', function () {
 
     it('works with legacy coordinate points', function (done) {
@@ -96,7 +97,7 @@ describe('model', function(){
 
         function next() {
           var pnt = { type : "Point", coordinates : [9,9] };
-          Geo.geoNear(pnt, { spherical : true, maxDistance : .1 }, function (err, results, stats) {
+          Geo.geoNear(pnt, { spherical : true, maxDistance : 100*1609 }, function (err, results, stats) {
             assert.ifError(err);
 
             assert.equal(1, results.length);
@@ -137,7 +138,7 @@ describe('model', function(){
 
         function next() {
           var pnt = { type : "Point", coordinates : [9,9] };
-          Geo.geoNear(pnt, { spherical : true, maxDistance : .1, lean : true }, function (err, results, stats) {
+          Geo.geoNear(pnt, { spherical : true, maxDistance : 100*1609, lean : true }, function (err, results, stats) {
             assert.ifError(err);
 
             assert.equal(1, results.length);


### PR DESCRIPTION
support [was added](https://github.com/mongodb/node-mongodb-native/pull/1198) to the mongodb native driver for passing a geoJSON point as is to the geoNear command.  this commit adds support for that in mongoose by modifying Model.geoNear to send a legacy coordinate pair OR a geoJSON point to the driver.