### PR TITLE
Include ValidatorError message in ValidationError. Fixes #2135 (ValidationError string representation shows no relevant details)

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -1030,6 +1030,10 @@ Document.prototype.validate = function (cb) {
 Document.prototype.invalidate = function (path, err, val) {
   if (!this.$__.validationError) {
     this.$__.validationError = new ValidationError(this);
+
+    if (err instanceof ValidatorError) {
+      this.$__.validationError.message += ': ' + err.toString();
+    }
   }
 
   if (!err || 'string' === typeof err) {

--- a/test/model.populate.test.js
+++ b/test/model.populate.test.js
@@ -1702,7 +1702,7 @@ describe('model: populate:', function(){
       });
 
       comment.save(function (err) {
-        assert.equal('Validation failed', err && err.message);
+        assert.equal('Validation failed: Path `str` is required.', err && err.message);
         assert.ok('num' in err.errors);
         assert.ok('str' in err.errors);
         assert.ok('user' in err.errors);

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -1044,7 +1044,7 @@ describe('Model', function(){
         db.close();
         assert.equal(err.errors.name.message, 'Name cannot be greater than 1 character for path "name" with value `hi`');
         assert.equal(err.name,"ValidationError");
-        assert.equal(err.message,"Validation failed");
+        assert.ok(/^Validation failed: Name cannot be greater/.test(err.message));
         done();
       });
     });

--- a/test/types.buffer.test.js
+++ b/test/types.buffer.test.js
@@ -66,7 +66,7 @@ describe('types.buffer', function(){
       });
 
       t.validate(function (err) {
-        assert.equal(err.message,'Validation failed');
+        assert.equal(err.message,'Validation failed: Path `required` is required.');
         assert.equal(err.errors.required.kind,'required');
         t.required = {x:[20]}
         t.save(function (err) {
@@ -79,11 +79,11 @@ describe('types.buffer', function(){
 
           t.sub.push({ name: 'Friday Friday' });
           t.save(function (err) {
-            assert.equal(err.message,'Validation failed');
+            assert.equal(err.message,'Validation failed: Path `buf` is required.');
             assert.equal(err.errors['sub.0.buf'].kind,'required');
             t.sub[0].buf = new Buffer("well well");
             t.save(function (err) {
-              assert.equal(err.message,'Validation failed');
+              assert.equal(err.message,'Validation failed: valid failed');
               assert.equal(err.errors['sub.0.buf'].kind,'user defined');
               assert.equal(err.errors['sub.0.buf'].message,'valid failed');
 


### PR DESCRIPTION
This improves the logging of `ValidationError`s, from simply 'Validation Error', to a more detailed 'Validation Error: X is required' style.

Fixes #2135, _ValidationError string representation shows no relevant details_.