### PR TITLE
What about this for updating individual embedded documents?

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -1275,33 +1275,52 @@ Document.prototype.$__registerHooks = function () {
       return val && val instanceof DocumentArray && val.length;
     });
 
-    if (!arrays.length)
+    var singleEmbeddedDocuments = this.$__.activePaths
+    .map('init', 'modify', function (i) {
+      var parts = i.split('.');
+      return parts.length === 1 ? self.getValue(i) : self.getValue(parts[0] + '.' + parts[1]);
+    })
+    .filter(function (val) {
+      // only include embedded documents whose parent array is not already included into the arrays array
+      return val && val.constructor.name === 'EmbeddedDocument' && val.__parentArray && arrays.indexOf(val.__parentArray) === -1;
+    });
+
+    if (!arrays.length && !singleEmbeddedDocuments.length)
       return next();
 
     // set saving embedded documents flag
     self.$__.savingEmbeddedDocuments = true;
 
-    arrays.forEach(function (array) {
+    singleEmbeddedDocuments.forEach(function (embeddedDocument) {
       if (error) return;
-
-      // handle sparse arrays by using for loop vs array.forEach
-      // which skips the sparse elements
-
-      var len = array.length
-      subdocs += len;
-
-      for (var i = 0; i < len; ++i) {
-        if (error) break;
-
-        var doc = array[i];
-        if (!doc) {
-          --subdocs || next();
-          continue;
-        }
-
-        doc.save(handleSave);
-      }
+      embeddedDocument.save(handleSave);
     });
+
+    if (!arrays.length) {
+      return next();
+    } else {
+      arrays.forEach(function (array) {
+        if (error) return;
+
+        // handle sparse arrays by using for loop vs array.forEach
+        // which skips the sparse elements
+
+        var len = array.length
+        subdocs += len;
+
+        for (var i = 0; i < len; ++i) {
+          if (error) break;
+
+          var doc = array[i];
+          if (!doc) {
+            --subdocs || next();
+            continue;
+          }
+
+          doc.save(handleSave);
+        }
+      });
+    }
 
     function handleSave (err) {
       if (error) return;

--- a/lib/document.js
+++ b/lib/document.js
@@ -1278,6 +1278,9 @@ Document.prototype.$__registerHooks = function () {
     if (!arrays.length)
       return next();
 
+    // set saving embedded documents flag
+    self.$__.savingEmbeddedDocuments = true;
+
     arrays.forEach(function (array) {
       if (error) return;
 
@@ -1312,6 +1315,9 @@ Document.prototype.$__registerHooks = function () {
     }
 
   }, function (err) {
+    // clear saving embedded documents flag
+    this.$__.savingEmbeddedDocuments = false;
+
     // emit on the Model if listening
     if (this.constructor.listeners('error').length) {
       this.constructor.emit('error', err);
@@ -1325,6 +1331,9 @@ Document.prototype.$__registerHooks = function () {
       this.db.emit('error', err);
     }
   }).pre('save', function checkForExistingErrors (next) {
+    // clear saving embedded documents flag
+    this.$__.savingEmbeddedDocuments = false;
+
     // if any doc.set() calls failed
     var err = this.$__.saveError;
     if (err) {

--- a/lib/types/embedded.js
+++ b/lib/types/embedded.js
@@ -126,8 +126,9 @@ EmbeddedDocument.prototype.save = function(fn) {
 
     // remove the modified state of the parent array path from the parent document
     var _this = this;
+    var indexedPathPrefix = path + '.' + this.__parentArray.indexOf(this) + '.';
     this.__parent.$__.activePaths.forEach(function(modifiedPath) {
-      if (modifiedPath.indexOf(path) === 0 && modifiedPath !== path) {
+      if (modifiedPath.indexOf(indexedPathPrefix) === 0 && modifiedPath !== indexedPathPrefix) {
         _this.__parent.$__.activePaths.ignore(modifiedPath);
       }
     });

--- a/lib/types/embedded.js
+++ b/lib/types/embedded.js
@@ -66,6 +66,8 @@ EmbeddedDocument.prototype.markModified = function (path) {
 };
 
 /**
+ * Supports for individual updates on first level embedded documents, otherwise the following applies:
+ *
  * Used as a stub for [hooks.js](https://github.com/bnoguchi/hooks-js/tree/31ec571cef0332e21121ee7157e0cf9728572cc3)
  *
  * ####NOTE:
@@ -78,8 +80,64 @@ EmbeddedDocument.prototype.markModified = function (path) {
  */
 
 EmbeddedDocument.prototype.save = function(fn) {
-  if (fn)
-    fn(null);
+  // support for individual updates on first level embedded documents
+  if (this.__parent && !this.__parent.__parent && !this.__parent.$__.savingEmbeddedDocuments) {
+    // bail if new
+    if (this.isNew || this.__parent.isNew) {
+      var err = new Error('Cannot save a new embedded document, this functionality is intended to work for updates only.');
+      if (fn) {
+        fn(err);
+      } else {
+        throw err;
+      }
+      return this;
+    }
+
+    // do nothing in case there are no modifications
+    if (!this.isModified()) {
+      if (fn)
+        fn(null);
+      return this;
+    }
+
+    // get options from the parent
+    var options = {};
+    if (this.__parent.schema.options.safe) {
+      options.safe = this.__parent.schema.options.safe;
+    }
+
+    // build match and update objects to take advantage of the positional operator ($)
+    var path = this.$__.fullPath;
+    var parentId = this.__parent._id;
+    var match = { _id: parentId };
+    match[path + '._id'] = this._id;
+    var modifiedPaths = this.modifiedPaths();
+    var update = { $set: {} };
+    for (var i = 0; i < modifiedPaths.length; i++) {
+      var currentPath = modifiedPaths[i];
+      var schemaType = this.schema.path(currentPath);
+      var rawValue = this.getValue(currentPath);
+      var value = rawValue;
+      if (schemaType) {
+        value = schemaType.cast(rawValue);
+      }
+      update.$set[path + '.$.' + modifiedPaths[i]] = value;
+    }
+
+    // remove the modified state of the parent array path from the parent document
+    var _this = this;
+    this.__parent.$__.activePaths.forEach(function(modifiedPath) {
+      if (modifiedPath.indexOf(path) === 0 && modifiedPath !== path) {
+        _this.__parent.$__.activePaths.ignore(modifiedPath);
+      }
+    });
+
+    this.$__reset();
+    this.__parent.collection.update(match, update, options, fn);
+  } else {
+    if (fn)
+      fn(null);
+  }
   return this;
 };
 

--- a/lib/types/embedded.js
+++ b/lib/types/embedded.js
@@ -124,7 +124,7 @@ EmbeddedDocument.prototype.save = function(fn) {
       update.$set[path + '.$.' + modifiedPaths[i]] = value;
     }
 
-    // remove the modified state of the parent array path from the parent document
+    // remove the modified state of this element path from the parent document
     var _this = this;
     var indexedPathPrefix = path + '.' + this.__parentArray.indexOf(this) + '.';
     this.__parent.$__.activePaths.forEach(function(modifiedPath) {

--- a/test/document.embedded.test.js
+++ b/test/document.embedded.test.js
@@ -182,6 +182,25 @@ describe('saving', function () {
       });
     });
 
+    it('should leave the doc as not modified when saving each modified embedded document', function (done) {
+      saveSampleDocument(function (err, db, M, doc) {
+        assert.ifError(err);
+        doc.cats[0].name = changedName;
+        doc.cats[1].name = changedName;
+        assert.equal(doc.isModified(), true);
+        doc.cats[0].save(function (err) {
+          assert.ifError(err);
+          assert.equal(doc.isModified(), true);
+          doc.cats[1].save(function (err) {
+            db.close();
+            assert.ifError(err);
+            assert.equal(doc.isModified(), false);
+            done();
+          });
+        });
+      });
+    });
+
     it('should include an error in the callback function when is new', function (done) {
       var db = start()
         , M = db.model(modelName);

--- a/test/document.embedded.test.js
+++ b/test/document.embedded.test.js
@@ -1,0 +1,179 @@
+
+/**
+ * Module dependencies.
+ */
+
+var start = require('./common')
+  , mongoose = start.mongoose
+  , assert = require('assert')
+  , Schema = mongoose.Schema
+  , ObjectId = Schema.ObjectId
+  , Document = require('../lib/document')
+  , EmbeddedDocument = require('../lib/types/embedded')
+  , DocumentObjectId = mongoose.Types.ObjectId;
+
+
+/**
+ * Setup
+ */
+
+var CatSchema = new Schema({
+  name: String
+});
+
+var CatOwnerSchema = new Schema({
+  name: String,
+  cats: [CatSchema]
+});
+
+var modelName = 'document.embedded.catowner';
+mongoose.model(modelName, CatOwnerSchema);
+
+var changedName = 'Changed name';
+
+/**
+ * This method will replace the doc collection's update method and notify the callback with the match and update params.
+ * After being executed once, it will restore the original method.
+ */
+
+var buildUpdateReplacement = function (doc, callback) {
+  var oldUpdate = doc.collection.update;
+  doc.collection.update = function (match, update, options, cb) {
+    callback(match, update);
+    doc.collection.update = oldUpdate;
+    oldUpdate.bind(doc.collection).apply(doc, arguments);
+  }
+};
+
+/**
+ * This method returns a saved document like this: { name: 'John Doe', cats: [ { name: 'Kitty 1' }, { name: 'Kitty 2' } ] }
+ */
+var saveSampleDocument = function (done) {
+  var db = start()
+    , M = db.model(modelName);
+
+  var doc = new M;
+
+  doc.name = 'John Doe';
+  doc.cats.push(doc.cats.create({ name: 'Kitty 1' }));
+  doc.cats.push(doc.cats.create({ name: 'Kitty 2' }));
+
+  doc.save(function (err) {
+    done(err, db, M, doc);
+  });
+};
+
+/**
+ * Test
+ */
+
+describe('saving', function () {
+  describe('an embedded document', function () {
+    it('should save changes by locating its id', function (done) {
+      saveSampleDocument(function (err, db, M, doc) {
+        assert.ifError(err);
+        var firstCat = doc.cats[0];
+        var catId = firstCat.id;
+        firstCat.name = changedName;
+        var matchSent, updateSent, called;
+        buildUpdateReplacement(doc, function (match, update) {
+          called = true;
+          matchSent = match;
+          updateSent = update;
+        });
+        firstCat.save(function (err) {
+          assert.equal(true, called);
+          assert.equal(catId, matchSent['cats._id']);
+          assert.equal(1, Object.keys(updateSent).length);
+          assert.equal('$set', Object.keys(updateSent)[0]);
+          assert.equal(1, Object.keys(updateSent.$set).length);
+          assert.equal('cats.$.name', Object.keys(updateSent.$set)[0]);
+          assert.equal(changedName, updateSent.$set['cats.$.name']);
+          M.findById(doc.id, function (err, foundDoc) {
+            db.close();
+            assert.ifError(err);
+            assert.equal(doc.id, foundDoc.id);
+            assert.equal(changedName, foundDoc.cats[0].name);
+            done();
+          });
+        });
+      });
+    });
+
+    it('should leave other paths untouched when saving', function (done) {
+      saveSampleDocument(function (err, db, M, doc) {
+        assert.ifError(err);
+        var newName = 'John';
+        doc.name = newName;
+        var firstCat = doc.cats[0];
+        firstCat.name = changedName;
+        firstCat.save(function (err) {
+          assert.ifError(err);
+          assert.equal(1, doc.modifiedPaths().length);
+          assert.equal('name', doc.modifiedPaths()[0]);
+          M.findById(doc.id, function (err, foundDoc) {
+            db.close();
+            assert.ifError(err);
+            assert.equal(doc.id, foundDoc.id);
+            assert.notEqual(newName, foundDoc.name);
+            done();
+          });
+        });
+      });
+    });
+
+    it('should include an error in the callback function when is new', function (done) {
+      var db = start()
+        , M = db.model(modelName);
+
+      var doc = new M;
+
+      doc.name = 'John Doe';
+      doc.cats.push(doc.cats.create({ name: 'Kitty 1' }));
+      doc.cats[0].save(function (err) {
+        db.close();
+        assert.notEqual(err, null);
+        done();
+      });
+    });
+
+    describe('upon an external change in its array element position', function () {
+      it('should still save the correct embedded document', function (done) {
+        saveSampleDocument(function (err, db, M, doc) {
+          assert.ifError(err);
+          var lotOfCats = [];
+          for (var i = 0; i < 1000; i++) {
+            lotOfCats.push({ _id: new DocumentObjectId(), name: 'Kitten ' + (1000 + i) });
+          }
+          M.collection.update({ _id: doc._id }, { $push: { cats: { $each: lotOfCats, $position: 0 } } }, function (err, modified) {
+            assert.ifError(err);
+            assert.equal(1, modified);
+            var firstCat = doc.cats[0];
+            firstCat.name = changedName;
+            firstCat.save(function (err) {
+              assert.ifError(err);
+              M.findById(doc.id, function (err, foundDoc) {
+                db.close();
+                assert.ifError(err);
+                assert.equal(doc.id, foundDoc.id);
+                assert.equal(changedName, foundDoc.cats.id(firstCat.id).name);
+                done();
+              });
+            });
+          });
+        });
+      });
+    });
+  });
+
+  afterEach(function (done) {
+    var db = start()
+      , M = db.model(modelName);
+
+    M.collection.remove({}, function (err) {
+      assert.ifError(err);
+      db.close();
+      done();
+    })
+  });
+});

--- a/test/document.embedded.test.js
+++ b/test/document.embedded.test.js
@@ -64,10 +64,69 @@ var saveSampleDocument = function (done) {
 };
 
 /**
+ *
+ */
+
+var createModelWithPreHook = function (modelName, parentCallback, childCallback, otherChildCallback) {
+  var childSchema = new Schema({ name: String});
+  var otherChildSchema = new Schema({ name: String});
+  var parentSchema = new Schema({ name: String, children: [childSchema], otherChildren: [otherChildSchema] });
+
+  childSchema.pre('save', function (next) {
+    if (childCallback)
+      childCallback();
+    next();
+  });
+
+  otherChildSchema.pre('save', function (next) {
+    if (otherChildSchema)
+      otherChildSchema();
+    next();
+  });
+
+  parentSchema.pre('save', function (next) {
+    if (parentCallback)
+      parentCallback();
+    next();
+  });
+  mongoose.model(modelName, parentSchema);
+};
+
+/**
  * Test
  */
 
 describe('saving', function () {
+  describe('a document with an embedded schema', function () {
+    it('should save the whole document as always', function (done) {
+      saveSampleDocument(function (err, db, M, doc) {
+        assert.ifError(err);
+        doc.name = changedName;
+        doc.cats[0].name = changedName;
+        doc.cats[1].name = changedName;
+        var called = false
+          , sentUpdate;
+        buildUpdateReplacement(doc, function (match, update) {
+          assert.equal(called, false);
+          called = true;
+          sentUpdate = update;
+        });
+        doc.save(function (err, doc) {
+          assert.ifError(err);
+          assert.equal(doc.isModified(), false);
+          M.findById(doc.id, function (err, doc) {
+            db.close();
+            assert.ifError(err);
+            assert.equal(doc.name, changedName);
+            assert.equal(doc.cats[0].name, changedName);
+            assert.equal(doc.cats[1].name, changedName);
+            done();
+          });
+        });
+      });
+    });
+  });
+
   describe('an embedded document', function () {
     it('should save changes by locating its id', function (done) {
       saveSampleDocument(function (err, db, M, doc) {
@@ -82,6 +141,7 @@ describe('saving', function () {
           updateSent = update;
         });
         firstCat.save(function (err) {
+          assert.ifError(err);
           assert.equal(true, called);
           assert.equal(catId, matchSent['cats._id']);
           assert.equal(1, Object.keys(updateSent).length);
@@ -138,6 +198,16 @@ describe('saving', function () {
     });
 
     describe('upon an external change in its array element position', function () {
+      var mongo26_or_greater = false;
+
+      before(function(done) {
+        start.mongodVersion(function (err, version) {
+          assert.ifError(err);
+          mongo26_or_greater = 2 < version[0] || (2 == version[0] && 6 <= version[1]);
+          done();
+        });
+      });
+
       it('should still save the correct embedded document', function (done) {
         saveSampleDocument(function (err, db, M, doc) {
           assert.ifError(err);
@@ -145,7 +215,15 @@ describe('saving', function () {
           for (var i = 0; i < 1000; i++) {
             lotOfCats.push({ _id: new DocumentObjectId(), name: 'Kitten ' + (1000 + i) });
           }
-          M.collection.update({ _id: doc._id }, { $push: { cats: { $each: lotOfCats, $position: 0 } } }, function (err, modified) {
+          var update = {};
+          if (mongo26_or_greater) {
+            update = { $push: { cats: { $each: lotOfCats, $position: 0 } } };
+          } else {
+            lotOfCats.push(doc.cats[0].toObject());
+            lotOfCats.push(doc.cats[1].toObject());
+            update = { $set: { cats: lotOfCats } };
+          }
+          M.collection.update({ _id: doc._id }, update, function (err, modified) {
             assert.ifError(err);
             assert.equal(1, modified);
             var firstCat = doc.cats[0];
@@ -161,6 +239,119 @@ describe('saving', function () {
               });
             });
           });
+        });
+      });
+    });
+  });
+
+  describe('should trigger hooks as expected', function () {
+    it('should call custom pre hooks for the main document and each modified embedded document', function (done) {
+      var parentCalls = 0
+        , childCalls = 0
+        , modelName = 'document.embedded.pre_hook_test_1';
+      createModelWithPreHook(modelName, function () { parentCalls++; }, function () { childCalls++; });
+
+      var db = start()
+        , Parent = db.model(modelName);
+      var doc = new Parent({ name: 'name', children: [ { name: 'name1' }, { name: 'name2' } ] });
+      doc.save(function (err, doc) {
+        db.close();
+        assert.ifError(err);
+        assert.equal(parentCalls, 1, 'only one parent call should have been made (' + parentCalls + ' found)');
+        assert.equal(childCalls, 2, 'only two child calls should have been made (' + childCalls + ' found)');
+        done();
+      });
+    });
+
+    it('multiple embedded changes, one embedded save and then a parent document save', function (done) {
+      var parentCalls = 0
+        , childCalls = 0
+        , modelName = 'document.embedded.pre_hook_test_2';
+      createModelWithPreHook(modelName, function () { parentCalls++; }, function () { childCalls++; });
+
+      var db = start()
+        , Parent = db.model(modelName);
+      var doc = new Parent({ name: 'name', children: [ { name: 'name1' }, { name: 'name2' } ] });
+      doc.save(function (err, doc) {
+        assert.ifError(err);
+        parentCalls = childCalls = 0;
+        doc.name = changedName;
+        doc.children[1].name = changedName;
+        doc.children[0].name = changedName;
+        doc.children[1].save(function (err) {
+          assert.ifError(err);
+          assert.equal(parentCalls, 0, 'no parent call should have been made (' + parentCalls + ' found)');
+          assert.equal(childCalls, 1, 'only one child call should have been made (' + childCalls + ' found)');
+          parentCalls = childCalls = 0;
+          doc.save(function (err) {
+            db.close();
+            assert.ifError(err);
+            assert.equal(parentCalls, 1, 'only one parent call should have been made (' + parentCalls + ' found)');
+            assert.equal(childCalls, 1, 'only one child call should have been made (' + childCalls + ' found)');
+            done();
+          });
+        });
+      });
+    });
+
+    it('embedded change, embedded save, twice, and then whole parent document', function (done) {
+      var parentCalls = 0
+        , childCalls = 0
+        , modelName = 'document.embedded.pre_hook_test_3';
+      createModelWithPreHook(modelName, function () { parentCalls++; }, function () { childCalls++; });
+
+      var db = start()
+        , Parent = db.model(modelName);
+      var doc = new Parent({ name: 'name', children: [ { name: 'name1' }, { name: 'name2' } ] });
+      doc.save(function (err, doc) {
+        assert.ifError(err);
+        parentCalls = childCalls = 0;
+        doc.name = changedName;
+        doc.children[1].name = changedName;
+        doc.children[1].save(function (err) {
+          assert.ifError(err);
+          assert.equal(parentCalls, 0, 'no parent call should have been made (' + parentCalls + ' found)');
+          assert.equal(childCalls, 1, 'only one child call should have been made (' + childCalls + ' found)');
+          parentCalls = childCalls = 0;
+          doc.children[0].name = changedName;
+          doc.children[0].save(function (err) {
+            assert.ifError(err);
+            assert.equal(parentCalls, 0, 'no parent call should have been made (' + parentCalls + ' found)');
+            assert.equal(childCalls, 1, 'only one child call should have been made (' + childCalls + ' found)');
+            parentCalls = childCalls = 0;
+            doc.save(function (err) {
+              db.close();
+              assert.ifError(err);
+              assert.equal(parentCalls, 1, 'only one parent call should have been made (' + parentCalls + ' found)');
+              assert.equal(childCalls, 0, 'only one child call should have been made (' + childCalls + ' found)');
+              done();
+            });
+          });
+        });
+      });
+    });
+
+    it('multiple embedded changes', function (done) {
+      var parentCalls = 0
+        , childCalls = 0
+        , modelName = 'document.embedded.pre_hook_test_4';
+      createModelWithPreHook(modelName, function () { parentCalls++; }, function () { childCalls++; });
+
+      var db = start()
+        , Parent = db.model(modelName);
+      var doc = new Parent({ name: 'name', children: [ { name: 'name1' }, { name: 'name2' } ] });
+      doc.save(function (err, doc) {
+        assert.ifError(err);
+        parentCalls = childCalls = 0;
+        doc.name = changedName;
+        doc.children = [ { name: 'child1' }, { name: 'child2' } ];
+        doc.children[1].name = changedName;
+        doc.save(function (err) {
+          db.close();
+          assert.ifError(err);
+          assert.equal(parentCalls, 1, 'no parent call should have been made (' + parentCalls + ' found)');
+          assert.equal(childCalls, 2, 'only one child call should have been made (' + childCalls + ' found)');
+          done();
         });
       });
     });

--- a/test/types.documentarray.test.js
+++ b/test/types.documentarray.test.js
@@ -350,11 +350,12 @@ describe('types.documentarray', function(){
 
     var p =new Post({ title: "comment nesting" });
     var c1 = p.comments.create({ title: "c1" });
-    var c2 = p.comments.create({ title: "c2" });
-    var c3 = p.comments.create({ title: "c3" });
-
     p.comments.push(c1);
+
+    var c2 = c1.comments.create({ title: "c2" });
     c1.comments.push(c2);
+
+    var c3 = c2.comments.create({ title: "c3" });
     c2.comments.push(c3);
 
     p.save(function (err) {


### PR DESCRIPTION
Hi, I just finished this. So I think the issue in question is old, basically Mongoose $sets subdocuments values using the position since the last load of the parent document, which might lead to write the wrong subdocument if an external change would change the array elements position.
My proposed solution (although it might not be complete yet) is to have the save method of EmbeddedDocument instances to use the collection update method to match the subdocument and $set values using the positional operator ($).

I'm new to Mongoose internals, so there might be some things that could have been taken in care in simpler, more robust ways. But I was able to write several tests, and keep the old ones pass.

Again, I'm not saying this is the ultimate, perfect solution, but I think it's definitely something that people with more experience in the project can take as a starting point and could polish.