### PR TITLE
Added globalConditions to schema options

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -21,6 +21,7 @@ var Document = require('./document')
   , Promise = require('./promise')
   , assert = require('assert')
   , util = require('util')
+  , utils = require('./utils')
   , tick = utils.tick;
 
 var VERSION_WHERE = 1
@@ -927,6 +928,8 @@ Model.remove = function remove (conditions, callback) {
     conditions = {};
   }
 
+  conditions = utils.options(conditions, this.schema.options.globalConditions);
+
   // get the mongodb collection object
   var mq = new Query(conditions, {}, this, this.collection);
 
@@ -996,6 +999,8 @@ Model.find = function find (conditions, fields, options, callback) {
     mq.select(this.schema.options.discriminatorKey);
   }
 
+  conditions = utils.options(conditions, this.schema.options.globalConditions);
+
   return mq.find(conditions, callback);
 };
 
@@ -1038,7 +1043,8 @@ Model.find = function find (conditions, fields, options, callback) {
  */
 
 Model.findById = function findById (id, fields, options, callback) {
-  return this.findOne({ _id: id }, fields, options, callback);
+  conditions = utils.options({ _id: id }, this.schema.options.globalConditions);
+  return this.findOne(conditions, fields, options, callback);
 };
 
 /**
@@ -1100,6 +1106,7 @@ Model.findOne = function findOne (conditions, fields, options, callback) {
   if (this.schema.discriminatorMapping && mq.selectedInclusively()) {
     mq.select(this.schema.options.discriminatorKey);
   }
+  conditions = utils.options(conditions, this.schema.options.globalConditions);
 
   return mq.findOne(conditions, callback);
 };
@@ -1126,7 +1133,7 @@ Model.count = function count (conditions, callback) {
 
   // get the mongodb collection object
   var mq = new Query({}, {}, this, this.collection);
-
+  conditions = utils.options(conditions, this.schema.options.globalConditions);
   return mq.count(conditions, callback);
 };
 
@@ -1157,6 +1164,7 @@ Model.count = function count (conditions, callback) {
 Model.distinct = function distinct (field, conditions, callback) {
   // get the mongodb collection object
   var mq = new Query({}, {}, this, this.collection);
+  conditions = utils.options(conditions, this.schema.options.globalConditions);
 
   if ('function' == typeof conditions) {
     callback = conditions;
@@ -1192,7 +1200,7 @@ Model.distinct = function distinct (field, conditions, callback) {
 
 Model.where = function where (path, val) {
   // get the mongodb collection object
-  var mq = new Query({}, {}, this, this.collection).find({});
+  var mq = new Query(this.schema.options.globalConditions, {}, this, this.collection).find({});
   return mq.where.apply(mq, arguments);
 };
 
@@ -1212,7 +1220,7 @@ Model.where = function where (path, val) {
  */
 
 Model.$where = function $where () {
-  var mq = new Query({}, {}, this, this.collection).find({});
+  var mq = new Query(this.schema.options.globalConditions, {}, this, this.collection).find({});
   return mq.$where.apply(mq, arguments);
 };
 
@@ -1310,6 +1318,7 @@ Model.findOneAndUpdate = function (conditions, update, options, callback) {
 
   var mq = new Query({}, {}, this, this.collection);
   mq.select(fields);
+  conditions = utils.options(conditions, this.schema.options.globalConditions);
 
   return mq.findOneAndUpdate(conditions, update, options, callback);
 }
@@ -1472,6 +1481,7 @@ Model.findOneAndRemove = function (conditions, options, callback) {
 
   var mq = new Query({}, {}, this, this.collection);
   mq.select(fields);
+  conditions = utils.options(conditions, this.schema.options.globalConditions);
 
   return mq.findOneAndRemove(conditions, options, callback);
 }
@@ -1680,6 +1690,8 @@ Model.hydrate = function (obj) {
 
 Model.update = function update (conditions, doc, options, callback) {
   var mq = new Query({}, {}, this, this.collection);
+  conditions = utils.options(conditions, this.schema.options.globalConditions);
+
   return mq.update(conditions, doc, options, callback);
 };
 
@@ -1979,6 +1991,8 @@ Model.geoSearch = function (conditions, options, callback) {
   if (conditions == undefined || !utils.isObject(conditions)) {
     return promise.error(new Error("Must pass conditions to geoSearch"));
   }
+
+  conditions = utils.options(conditions, this.schema.options.globalConditions);
 
   if (!options.near) {
     return promise.error(new Error("Must specify the near option in geoSearch"));

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -185,7 +185,7 @@ Schema.prototype.defaultOptions = function (options) {
 
   options = utils.options({
       strict: true
-    , this.globalConditions = {}
+    , globalConditions = {}
     , bufferCommands: true
     , capped: false // { size, max, autoIndexId }
     , versionKey: '__v'

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -185,6 +185,7 @@ Schema.prototype.defaultOptions = function (options) {
 
   options = utils.options({
       strict: true
+    , this.globalConditions = {}
     , bufferCommands: true
     , capped: false // { size, max, autoIndexId }
     , versionKey: '__v'

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -185,7 +185,7 @@ Schema.prototype.defaultOptions = function (options) {
 
   options = utils.options({
       strict: true
-    , globalConditions = {}
+    , globalConditions: {}
     , bufferCommands: true
     , capped: false // { size, max, autoIndexId }
     , versionKey: '__v'


### PR DESCRIPTION
This allows you to apply a fixed condition to every mongoldb query.

Example:
var userSchema = new Schema({
    globalConditions: {
        _type: 'user',
    },
    collection: 'accounts',
});

var adminSchema = new Schema({
    globalConditions: {
        _type: 'admin',
    },
    collection: 'accounts',
});

var accountSchema = new Schema({
    collection: 'accounts',
});

This way you can easily manage single table inheritance.