### PR TITLE
Added built in minlength and maxlength validators to the String schema type

### DIFF
--- a/lib/error/messages.js
+++ b/lib/error/messages.js
@@ -38,4 +38,6 @@ msg.Date.max = "Path `{PATH}` ({VALUE}) is after maximum allowed value ({MAX})."
 msg.String = {};
 msg.String.enum = "`{VALUE}` is not a valid enum value for path `{PATH}`.";
 msg.String.match = "Path `{PATH}` is invalid ({VALUE}).";
+msg.String.minlength = "Path `{PATH}` (`{VALUE}`) is shorter than the minimum allowed length ({MINLENGTH}).";
+msg.String.maxlength = "Path `{PATH}` (`{VALUE}`) is longer than the maximum allowed length ({MAXLENGTH}).";
 

--- a/lib/schema/string.js
+++ b/lib/schema/string.js
@@ -182,6 +182,112 @@ SchemaString.prototype.trim = function () {
 };
 
 /**
+ * Sets a minimum length validator.
+ *
+ * ####Example:
+ *
+ *     var schema = new Schema({ postalCode: { type: String, minlength: 5 })
+ *     var Address = db.model('Address', schema)
+ *     var address = new Address({ postalCode: '9512' })
+ *     address.save(function (err) {
+ *       console.error(err) // validator error
+ *       address.postalCode = '95125';
+ *       address.save() // success
+ *     })
+ *
+ *     // custom error messages
+ *     // We can also use the special {MINLENGTH} token which will be replaced with the invalid value
+ *     var minlength = [10, 'The value of path `{PATH}` (`{VALUE}`) is shorter than the minimum length ({MINLENGTH}).'];
+ *     var schema = new Schema({ postalCode: { type: String, minlength: minlength })
+ *     var Address = mongoose.model('Address', schema);
+ *     var address = new Address({ postalCode: '9512' });
+ *     s.validate(function (err) {
+ *       console.log(String(err)) // ValidationError: The value of path `postalCode` (`9512`) is shorter than the minimum length (5).
+ *     })
+ *
+ * @param {Number} value minimum string length
+ * @param {String} [message] optional custom error message
+ * @return {SchemaType} this
+ * @see Customized Error Messages #error_messages_MongooseError-messages
+ * @api public
+ */
+
+SchemaString.prototype.minlength = function (value, message) {
+  if (this.minlengthValidator) {
+    this.validators = this.validators.filter(function (v) {
+      return v.validator != this.minlengthValidator;
+    }, this);
+  }
+
+  if (null != value) {
+    var msg = message || errorMessages.String.minlength;
+    msg = msg.replace(/{MINLENGTH}/, value);
+    this.validators.push({
+      validator: this.minlengthValidator = function (v) {
+        return v === null || v.length >= value;
+      },
+      message: msg,
+      type: 'minlength'
+    });
+  }
+
+  return this;
+};
+
+/**
+ * Sets a maximum length validator.
+ *
+ * ####Example:
+ *
+ *     var schema = new Schema({ postalCode: { type: String, maxlength: 9 })
+ *     var Address = db.model('Address', schema)
+ *     var address = new Address({ postalCode: '9512512345' })
+ *     address.save(function (err) {
+ *       console.error(err) // validator error
+ *       address.postalCode = '95125';
+ *       address.save() // success
+ *     })
+ *
+ *     // custom error messages
+ *     // We can also use the special {MAXLENGTH} token which will be replaced with the invalid value
+ *     var maxlength = [10, 'The value of path `{PATH}` (`{VALUE}`) exceeds the maximum allowed length ({MAXLENGTH}).'];
+ *     var schema = new Schema({ postalCode: { type: String, maxlength: maxlength })
+ *     var Address = mongoose.model('Address', schema);
+ *     var address = new Address({ postalCode: '9512512345' });
+ *     address.validate(function (err) {
+ *       console.log(String(err)) // ValidationError: The value of path `postalCode` (`9512512345`) exceeds the maximum allowed length (10).
+ *     })
+ *
+ * @param {Number} value maximum string length
+ * @param {String} [message] optional custom error message
+ * @return {SchemaType} this
+ * @see Customized Error Messages #error_messages_MongooseError-messages
+ * @api public
+ */
+
+SchemaString.prototype.maxlength = function (value, message) {
+  if (this.maxlengthValidator) {
+    this.validators = this.validators.filter(function(v){
+      return v.validator != this.maxlengthValidator;
+    }, this);
+  }
+
+  if (null != value) {
+    var msg = message || errorMessages.String.maxlength;
+    msg = msg.replace(/{MAXLENGTH}/, value);
+    this.validators.push({
+      validator: this.maxlengthValidator = function(v) {
+        return v === null || v.length <= value;
+      },
+      message: msg,
+      type: 'maxlength'
+    });
+  }
+
+  return this;
+};
+
+/**
  * Sets a regexp validator.
  *
  * Any value that does not pass `regExp`.test(val) will fail validation.

--- a/test/errors.validation.test.js
+++ b/test/errors.validation.test.js
@@ -106,6 +106,66 @@ describe('ValidationError', function(){
     });
   });
 
+  describe('#minlength', function() {
+    it('causes a validation error', function(done) {
+      var AddressSchema
+        , Address
+        , model;
+
+      AddressSchema = new Schema({
+        postalCode : { type: String, minlength: 5 }
+      });
+
+      Address = mongoose.model('MinLengthAddress', AddressSchema);
+
+      model = new Address({
+        postalCode: '9512'
+      });
+
+      //should fail validation
+      model.validate(function(err){
+        assert.notEqual(err, null, 'String minlegth validation failed.');
+        model.postalCode = '95125';
+
+        //should pass validation
+        model.validate(function(err) {
+          assert.equal(err, null);
+          done();  
+        });
+      });
+    });
+  });
+
+  describe('#maxlength', function() {
+    it('causes a validation error', function(done) {
+      var AddressSchema
+        , Address
+        , model;
+
+      AddressSchema = new Schema({
+        postalCode : { type: String, maxlength: 10 }
+      });
+
+      Address = mongoose.model('MaxLengthAddress', AddressSchema);
+
+      model = new Address({
+        postalCode: '95125012345'
+      });
+
+      //should fail validation
+      model.validate(function(err){
+        assert.notEqual(err, null, 'String maxlegth validation failed.');
+        model.postalCode = '95125';
+
+        //should pass validation
+        model.validate(function(err) {
+          assert.equal(err, null);
+          done();  
+        });
+      });
+    });
+  });
+
   describe('#toString', function() {
     it('does not cause RangeError (gh-1296)', function(done) {
       var ASchema = new Schema({

--- a/test/errors.validation.test.js
+++ b/test/errors.validation.test.js
@@ -65,7 +65,7 @@ describe('ValidationError', function(){
       //should fail validation
       model.validate(function(err){
         assert.notEqual(err, null, 'min Date validation failed.');
-        model.appointmentDate = Date.now();
+        model.appointmentDate = new Date(Date.now().valueOf() + 10000);
 
         //should pass validation
         model.validate(function(err) {


### PR DESCRIPTION
Similar to the basic min/max validators for the Number schema type, I've added minlength and maxlength validators for the String schema type, along with tests and default validation messages. 