### PR TITLE
Allow explicitly excluding paths from versioning

### DIFF
--- a/docs/guide.jade
+++ b/docs/guide.jade
@@ -252,7 +252,7 @@ block content
     - [toObject](#toObject)
     - [validateBeforeSave](#validateBeforeSave)
     - [versionKey](#versionKey)
-    - [notVersionedPaths](#notVersionedPaths)
+    - [skipVersioning](#skipVersioning)
 
   h4#autoIndex option: autoIndex
   :markdown
@@ -521,13 +521,12 @@ block content
     var thing = new Thing({ name: 'no versioning please' });
     thing.save(); // { name: 'no versioning please' }
 
-    h4#notVersionedPaths option: notVersionedPaths
+    h4#skipVersioning option: skipVersioning
   :markdown
-    `notVersionedPaths` is a set of safe paths which are excluded from versioning (i.e the internal revision will not be incremented even if non-versioned paths change). DO NOT do this unless you know what you're doing.
+    `skipVersioning` allows excluding paths from versioning (i.e the internal revision will not be incremented even if these paths are updated). DO NOT do this unless you know what you're doing.
   :js
-    new Schema({..}, { notVersionedPaths: [ 'dontIncrementVersionEvenIfIChange' ] });
-    var Thing = mongoose.model('Thing', schema);
-    var thing = new Thing({ dontIncrementVersionEvenIfIChange: [ { ... }] });
+    new Schema({..}, { skipVersioning: { dontVersionMe: true } });
+    thing.dontVersionMe.push('hey');
     thing.save(); // version is not incremented
 
   h3#plugins Pluggable

--- a/docs/guide.jade
+++ b/docs/guide.jade
@@ -523,7 +523,7 @@ block content
 
     h4#notVersionedPaths option: notVersionedPaths
   :markdown
-    `notVersionedPaths` is a set of safe paths which are excluded from versioning (i.e the internal revision will not be incremented even if nonVersioned paths change). DO NOT do this unles you know what you're doing.
+    `notVersionedPaths` is a set of safe paths which are excluded from versioning (i.e the internal revision will not be incremented even if non-versioned paths change). DO NOT do this unless you know what you're doing.
   :js
     new Schema({..}, { notVersionedPaths: [ 'dontIncrementVersionEvenIfIChange' ] });
     var Thing = mongoose.model('Thing', schema);

--- a/docs/guide.jade
+++ b/docs/guide.jade
@@ -252,6 +252,7 @@ block content
     - [toObject](#toObject)
     - [validateBeforeSave](#validateBeforeSave)
     - [versionKey](#versionKey)
+    - [notVersionedPaths](#notVersionedPaths)
 
   h4#autoIndex option: autoIndex
   :markdown
@@ -519,6 +520,15 @@ block content
     var Thing = mongoose.model('Thing', schema);
     var thing = new Thing({ name: 'no versioning please' });
     thing.save(); // { name: 'no versioning please' }
+
+    h4#notVersionedPaths option: notVersionedPaths
+  :markdown
+    `notVersionedPaths` is a set of safe paths which are excluded from versioning (i.e the internal revision will not be incremented even if nonVersioned paths change). DO NOT do this unles you know what you're doing.
+  :js
+    new Schema({..}, { notVersionedPaths: [ 'dontIncrementVersionEvenIfIChange' ] });
+    var Thing = mongoose.model('Thing', schema);
+    var thing = new Thing({ dontIncrementVersionEvenIfIChange: [ { ... }] });
+    thing.save(); // version is not incremented
 
   h3#plugins Pluggable
   p

--- a/lib/model.js
+++ b/lib/model.js
@@ -287,9 +287,9 @@ function operand (self, where, delta, data, val, op) {
   // disabled versioning?
   if (false === self.schema.options.versionKey) return;
 
-  // path excluded from versioning
-  var notVersionedPaths = self.schema.options.notVersionedPaths;
-  if (notVersionedPaths && notVersionedPaths.indexOf(data.path) >= 0) return;
+  // path excluded from versioning?
+  var skipVersioning = self.schema.options.skipVersioning;
+  if (skipVersioning && skipVersioning[data.path]) return;
 
   // already marked for versioning?
   if (VERSION_ALL === (VERSION_ALL & self.$__.version)) return;

--- a/lib/model.js
+++ b/lib/model.js
@@ -287,6 +287,10 @@ function operand (self, where, delta, data, val, op) {
   // disabled versioning?
   if (false === self.schema.options.versionKey) return;
 
+  // path excluded from versioning
+  var notVersionedPaths = self.schema.options.notVersionedPaths;
+  if (notVersionedPaths && notVersionedPaths.indexOf(data.path) >= 0) return;
+
   // already marked for versioning?
   if (VERSION_ALL === (VERSION_ALL & self.$__.version)) return;
 

--- a/test/versioning.test.js
+++ b/test/versioning.test.js
@@ -43,11 +43,12 @@ var BlogPost = new Schema({
       , nested    : [Comments]
       , numbers   : [Number]
     }
-  , mixed     : {}
-  , numbers   : [Number]
-  , comments  : [Comments]
-  , arr       : []
-}, { collection: 'versioning_' + random()});
+  , mixed        : {}
+  , numbers      : [Number]
+  , comments     : [Comments]
+  , arr          : []
+  , dontVersionMe: []
+}, { collection: 'versioning_' + random(), skipVersioning: { dontVersionMe: true } });
 
 
 mongoose.model('Versioning', BlogPost);
@@ -254,9 +255,20 @@ describe('versioning', function(){
       assert.ok(d[1].$set, 'two differing atomic ops on same path should create a $set');
       assert.ok(d[1].$inc, 'a $set of an array should trigger versioning');
       assert.ok(!d[1].$addToSet);
+      save(a, b, test13);
+    }
 
-      db.close();
-      done();
+    function test13 (err, a, b) {
+        assert.ifError(err);
+        a.dontVersionMe.push('value1');
+        b.dontVersionMe.push('value2');
+        save(a, b, test14);
+    }
+
+    function test14 (err, a, b) {
+        assert.equal(a._doc.__v, 13, 'version should not be incremented for non-versioned fields');
+        db.close();
+        done();
     }
 
     function save (a, b, cb) {


### PR DESCRIPTION
First of all versioning is super useful. Thanks!

I'd like the ability to exclude certain array paths though. If elements in an array are only ever soft-deleted or properties updated one-by-one there's no point in including it in versioning and can result in false positive ```VersionError```s on concurrent updates.

Suggested syntax: 
```js
schema.set('notVersionedPaths',['safeArrayPath']);
```

Happy to contribute this with whatever other syntax/naming you prefer. 

What do you think? Are you interested in something like this?