### PR TITLE
Fix #2587

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "dependencies": {
     "hooks": "0.3.2",
-    "mongodb": "1.4.12",
+    "mongodb": "1.4.28",
     "ms": "0.1.0",
     "sliced": "0.0.5",
     "muri": "0.3.1",


### PR DESCRIPTION
Latest MongoDB server causes TypeError: Cannot read property 'length' of undefined.

Upgraded package.json to latest 1.4.28