### PR TITLE
Fix #2587

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   , "author": "Guillermo Rauch <guillermo@learnboost.com>"
   , "keywords": ["mongodb", "document", "model", "schema", "database", "odm", "data", "datastore", "query", "nosql", "orm", "db"]
   , "dependencies": {
-        "mongodb": "1.4.12"
+        "mongodb": "1.4.28"
       , "hooks": "0.2.1"
       , "ms": "0.1.0"
       , "sliced": "0.0.5"


### PR DESCRIPTION
Latest MongoDB server causes TypeError: Cannot read property 'length' of undefined.

Upgraded package.json to latest 1.4.28