### PR TITLE
fixing conflict in findAndModify --> follow-up to #2519

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -1528,7 +1528,9 @@ Query.prototype._findAndModify = function (type, callback) {
   } else {
     if (!('new' in opts)) opts.new = true;
     if (!('upsert' in opts)) opts.upsert = false;
-    if (opts.upsert) opts.remove = false;
+    if (opts.upsert || opts.new) {
+      opts.remove = false;
+    }
     
     castedDoc = castDoc(this, opts.overwrite);
     if (!castedDoc) {


### PR DESCRIPTION
disabling opts.remove when opts.new resolves to true.

This resolves a similar issue to the one discussed in #2519 but related to the "new" property.