### PR TITLE
make model.hydrate use createModel so that it works with discriminators

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -1650,10 +1650,9 @@ Model.create = function create (doc, fn) {
  */
 
 Model.hydrate = function (obj) {
-  var doc = this(obj);
-  doc.$__reset();
-  doc.isNew = false;
-  return doc;
+  var model = require('./queryhelpers').createModel(this, obj);
+  model.init(obj);
+  return model;
 };
 
 /**

--- a/test/model.hydrate.test.js
+++ b/test/model.hydrate.test.js
@@ -13,9 +13,17 @@ var start = require('./common')
  * Setup
  */
 
-var schema = Schema({
-    title: String
-})
+var schemaB = Schema({
+    title: String,
+    type: String
+}, {discriminatorKey: 'type'});
+
+var schemaC = Schema({
+  test: {
+    type: String,
+    default: 'test'
+  }
+}, {discriminatorKey: 'type'});
 
 
 describe('model', function(){
@@ -25,7 +33,8 @@ describe('model', function(){
 
     before(function(){
       db = start();
-      B = db.model('model-create', schema, 'model-create-'+random());
+      B = db.model('model-create', schemaB, 'model-create-'+random());
+      B.discriminator('C', schemaC);
     })
 
     after(function(done){
@@ -42,6 +51,14 @@ describe('model', function(){
       assert.equal(hydrated.isModified(), false);
       assert.equal(hydrated.isModified('title'), false);
 
+      done();
+    });
+
+    it('works correctly with model discriminators', function(done) {
+      var hydrated = B.hydrate({_id: '541085faedb2f28965d0e8e8', title: 'chair', type: 'C'});
+
+      assert.equal(hydrated.test, 'test');
+      assert.ok(hydrated.schema === schemaC);
       done();
     });
   });


### PR DESCRIPTION
It seems like hydrate should work with discriminators.  Also i'm not sure why, but if I require queryhelpers outside of the function it breaks several tests, which is why i'm doing it in the awkward way that I am.  Not sure if there is a workaround for that.