### PR TITLE
Dont run validators more than once for nested subdocuments

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -639,7 +639,7 @@ Document.prototype.$__set = function (
     } else {
       if (obj[parts[i]] && 'Object' === obj[parts[i]].constructor.name) {
         obj = obj[parts[i]];
-      } else if (obj[parts[i]] && 'EmbeddedDocument' === obj[parts[i]].constructor.name) {  
+      } else if (obj[parts[i]] && 'EmbeddedDocument' === obj[parts[i]].constructor.name) {
         obj = obj[parts[i]];
       } else if (obj[parts[i]] && Array.isArray(obj[parts[i]])) {
         obj = obj[parts[i]];
@@ -1157,12 +1157,12 @@ function compile (tree, proto, prefix) {
 // makes all properties non-enumerable to match previous behavior to #2211
 function getOwnPropertyDescriptors(object) {
   var result = {};
-  
+
   Object.getOwnPropertyNames(object).forEach(function(key) {
     result[key] = Object.getOwnPropertyDescriptor(object, key);
     result[key].enumerable = false;
   });
-  
+
   return result;
 }
 
@@ -1258,6 +1258,29 @@ Document.prototype.$__registerHooks = function () {
 
   DocumentArray || (DocumentArray = require('./types/documentarray'));
 
+  function emitErrorOnModel(err) {
+    // emit on the Model if listening
+    if (this.constructor.listeners('error').length) {
+      this.constructor.emit('error', err);
+    } else {
+      // emit on the connection
+      if (!this.db.listeners('error').length) {
+        err.stack = 'No listeners detected, throwing. '
+                  + 'Consider adding an error listener to your connection.\n'
+                  + err.stack
+      }
+      this.db.emit('error', err);
+    }
+  }
+
+  // Don't duplicate calls to validate() on sub-documents
+  // validate already descends the object tree on its own
+  if(! this.parent || ! this.parent()) {
+    this.pre('save', function validation (next) {
+      return this.validate(next);
+    }, emitErrorOnModel);
+  }
+
   this.pre('save', function (next) {
     // validate all document arrays.
     // we keep the error semaphore to make sure we don't
@@ -1311,20 +1334,7 @@ Document.prototype.$__registerHooks = function () {
       --subdocs || next();
     }
 
-  }, function (err) {
-    // emit on the Model if listening
-    if (this.constructor.listeners('error').length) {
-      this.constructor.emit('error', err);
-    } else {
-      // emit on the connection
-      if (!this.db.listeners('error').length) {
-        err.stack = 'No listeners detected, throwing. '
-                  + 'Consider adding an error listener to your connection.\n'
-                  + err.stack
-      }
-      this.db.emit('error', err);
-    }
-  }).pre('save', function checkForExistingErrors (next) {
+  }, emitErrorOnModel).pre('save', function checkForExistingErrors (next) {
     // if any doc.set() calls failed
     var err = this.$__.saveError;
     if (err) {
@@ -1333,8 +1343,6 @@ Document.prototype.$__registerHooks = function () {
     } else {
       next();
     }
-  }).pre('save', function validation (next) {
-    return this.validate(next);
   });
 
   // add user defined queues

--- a/lib/query.js
+++ b/lib/query.js
@@ -699,12 +699,16 @@ Query.prototype.toConstructor = function toConstructor () {
  *
  * ####Example
  *
- *     // include a and b, exclude c
- *     query.select('a b -c');
+ *     // include a and b, exclude other fields
+ *     query.select('a b');
+ *
+ *     // exclude c and d, include other fields
+ *     query.select('-c -d');
  *
  *     // or you may use object notation, useful when
  *     // you have keys already prefixed with a "-"
- *     query.select({a: 1, b: 1, c: 0});
+ *     query.select({ a: 1, b: 1 });
+ *     query.select({ c: 0, d: 0 });
  *
  *     // force inclusion of field excluded at schema level
  *     query.select('+path')


### PR DESCRIPTION
Fix for #2617.  I had to change the 'nested subdocuments' test a little bit, because it was asserting that mongoose not return all of the errors that were actually wrong with the document, which didn't seem like the right behavior to me, but it is possibly a breaking change for code that depends on that behavior.  Not sure if it was actually intended to work that way though.