### PR TITLE
Fix #2442: mark whole array as modified if db doesn't think its an array

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -292,7 +292,9 @@ function init (self, obj, doc, prefix) {
         }
       }
       // mark as hydrated
-      self.$__.activePaths.init(path);
+      if (!self.isModified(path)) {
+        self.$__.activePaths.init(path);
+      }
     }
   }
 };

--- a/lib/schema/array.js
+++ b/lib/schema/array.js
@@ -152,6 +152,11 @@ SchemaArray.prototype.cast = function (value, doc, init) {
 
     return value;
   } else {
+    // gh-2442: if we're loading this from the db and its not an array, mark
+    // the whole array as modified.
+    if (!!doc && !!init) {
+      doc.markModified(this.path);
+    }
     return this.cast([value], doc, init);
   }
 };

--- a/lib/schema/documentarray.js
+++ b/lib/schema/documentarray.js
@@ -118,6 +118,11 @@ DocumentArray.prototype.cast = function (value, doc, init, prev) {
     , i
 
   if (!Array.isArray(value)) {
+    // gh-2442 mark whole array as modified if we're initializing a doc from
+    // the db and the path isn't an array in the document
+    if (!!doc && init) {
+      doc.markModified(this.path);
+    }
     return this.cast([value], doc, init, prev);
   }
 


### PR DESCRIPTION
See #2442. When we're hydrating a doc from the db, if it has a field that mongoose thinks is an array but the db thinks is not an array, we can get some messy behavior where mongoose tries to set `array.0.value` on a non-array. To deal with this, just mark the whole array path as modified if we're initializing the doc and we don't get an array.