### PR TITLE
Adding optional type support to SchemaType.prototype.validate()

### DIFF
--- a/lib/schematype.js
+++ b/lib/schematype.js
@@ -392,14 +392,15 @@ SchemaType.prototype.get = function (fn) {
  *
  * @param {RegExp|Function|Object} obj validator
  * @param {String} [errorMsg] optional error message
+ * @param {String} [type] optional error type
  * @return {SchemaType} this
  * @api public
  */
 
-SchemaType.prototype.validate = function (obj, message) {
+SchemaType.prototype.validate = function (obj, message, type) {
   if ('function' == typeof obj || obj && 'RegExp' === obj.constructor.name) {
     if (!message) message = errorMessages.general.default;
-    this.validators.push([obj, message, 'user defined']);
+    this.validators.push([obj, message, type || 'user defined']);
     return this;
   }
 
@@ -415,7 +416,7 @@ SchemaType.prototype.validate = function (obj, message) {
 
       throw new Error(msg);
     }
-    this.validate(arg.validator, arg.msg);
+    this.validate(arg.validator, arg.msg, arg.type);
   }
 
   return this;


### PR DESCRIPTION
The validate method does not support the optional ValiatorError 'type' field. This PR adds support for that. It is a benign change that should require no regression.