### PR TITLE
Added "instance" property strings for Array, Boolean, Date, and Mixed schema types

### DIFF
--- a/lib/schema/array.js
+++ b/lib/schema/array.js
@@ -61,7 +61,7 @@ function SchemaArray (key, cast, options) {
     }
   }
 
-  SchemaType.call(this, key, options);
+  SchemaType.call(this, key, options, 'Array');
 
   var self = this
     , defaultArr

--- a/lib/schema/boolean.js
+++ b/lib/schema/boolean.js
@@ -15,7 +15,7 @@ var utils = require('../utils');
  */
 
 function SchemaBoolean (path, options) {
-  SchemaType.call(this, path, options);
+  SchemaType.call(this, path, options, 'Boolean');
 }
 
 /**

--- a/lib/schema/date.js
+++ b/lib/schema/date.js
@@ -17,7 +17,7 @@ var SchemaType = require('../schematype')
  */
 
 function SchemaDate (key, options) {
-  SchemaType.call(this, key, options);
+  SchemaType.call(this, key, options, 'Date');
 }
 
 /**

--- a/lib/schema/mixed.js
+++ b/lib/schema/mixed.js
@@ -31,7 +31,7 @@ function Mixed (path, options) {
     }
   }
 
-  SchemaType.call(this, path, options);
+  SchemaType.call(this, path, options, 'Mixed');
 }
 
 /**


### PR DESCRIPTION
The `Array`, `Boolean`, `Date`, and `Mixed` schema types don't define an `instance` property in `SchemaType.call(...)`, thus resulting in `undefined` being set when `SchemaType` sets `this.instance` in lib/schematype.js:

    function SchemaType (path, options, instance) {
      this.path = path;
      this.instance = instance;

See previous conversations requesting standard behavior at:

 - https://github.com/LearnBoost/mongoose/issues/1430
 - https://github.com/LearnBoost/mongoose/issues/1938

This PR is very simple, it just provides these strings so that anyone loading a Mongoose model can check the instance's schema type. This is useful, for example, if one wishes to load Mongoose models and describe their schema programmatically. Even without this use case, though, I think that the `instance` being set should be normalized.
