### PR TITLE
Set default toObject() options after checking if parameter exists

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -1666,10 +1666,6 @@ Document.prototype.$__handleReject = function handleReject(err) {
 
 Document.prototype.toObject = function (options) {
   var defaultOptions = { transform: true };
-  for (var key in options) {
-    defaultOptions[key] = options[key];
-  }
-  options = defaultOptions;
 
   if (options && options.depopulate && !options._skipDepopulateTopLevel && this.$__.wasPopulated) {
     // populated paths that we set to a document
@@ -1690,6 +1686,12 @@ Document.prototype.toObject = function (options) {
     options = this.schema.options.toObject
       ? clone(this.schema.options.toObject)
       : {};
+  }
+
+  for (var key in defaultOptions) {
+    if (options[key] === undefined) {
+      options[key] = defaultOptions[key];
+    }
   }
 
   ;('minimize' in options) || (options.minimize = this.schema.options.minimize);


### PR DESCRIPTION
Fixes #2751. Thanks for pointing this out @whitecolor