### PR TITLE
Mark paths as valid on successful set

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -513,7 +513,7 @@ Document.prototype.set = function (path, val, type, options) {
       this.set(val, path, constructing);
       return this;
     }
-    this.$__error(new MongooseError.CastError('Object', val, path));
+    this.invalidate(path, new MongooseError.CastError('Object', val, path));
     return this;
   }
 
@@ -593,6 +593,7 @@ Document.prototype.set = function (path, val, type, options) {
       this.populated(path, val._id);
     }
     val = schema.applySetters(val, this, false, priorVal);
+    this.$markValid(path);
   } catch (e) {
     this.invalidate(e.path, new ValidatorError({
       path: e.path,
@@ -973,12 +974,6 @@ Document.prototype.validate = function (cb) {
   var self = this;
   var promise = new Promise(cb);
 
-  var preSaveErr = self.$__presaveValidate();
-  if (preSaveErr) {
-    promise.reject(preSaveErr);
-    return promise;
-  }
-
   // only validate required fields when necessary
   var paths = Object.keys(this.$__.activePaths.states.require).filter(function (path) {
     if (!self.isSelected(path) && !self.isModified(path)) return false;
@@ -1024,6 +1019,10 @@ Document.prototype.validate = function (cb) {
     process.nextTick(function(){
       var p = self.schema.path(path);
       if (!p) return --total || complete();
+      if (!self.$isValid(path)) {
+        --total || complete();
+        return;
+      }
 
       var val = self.getValue(path);
       p.doValidate(val, function (err) {
@@ -1089,10 +1088,13 @@ Document.prototype.validateSync = function () {
 
     var p = self.schema.path(path);
     if (!p) return;
+    if (!self.$isValid(path)) {
+      return;
+    }
 
     var val = self.getValue(path);
-    var err = p.doValidateSync( val, self );
-    if ( err ){
+    var err = p.doValidateSync(val, self);
+    if (err) {
       self.invalidate(path, err, undefined, true);
     }
   });
@@ -1152,7 +1154,36 @@ Document.prototype.invalidate = function (path, err, val) {
   if (this.$__.validationError == err) return;
 
   this.$__.validationError.errors[path] = err;
-}
+};
+
+/**
+ * Marks a path as valid, removing existing validation errors.
+ *
+ * @param {String} path the field to mark as valid
+ * @api private
+ */
+
+Document.prototype.$markValid = function(path) {
+  if (!this.$__.validationError || !this.$__.validationError.errors[path]) {
+    return;
+  }
+
+  delete this.$__.validationError.errors[path];
+  if (Object.keys(this.$__.validationError.errors).length === 0) {
+    this.$__.validationError = null;
+  }
+};
+
+/**
+ * Checks if a path is invalid
+ *
+ * @param {String} path the field to check
+ * @api private
+ */
+
+Document.prototype.$isValid = function(path) {
+  return !this.$__.validationError || !this.$__.validationError.errors[path];
+};
 
 /**
  * Resets the internal modified state of this document.
@@ -1440,46 +1471,6 @@ Document.prototype.$__getAllSubdocs = function () {
   var subDocs = Object.keys(this._doc).reduce(docReducer.bind(this), []);
 
   return subDocs;
-};
-
-
-/**
- * Handle generic save stuff.
- * to solve #1446 use use hierarchy instead of hooks
- *
- * @api private
- * @method $__presaveValidate
- * @memberOf Document
- */
-
-Document.prototype.$__presaveValidate = function $__presaveValidate() {
-  // if any doc.set() calls failed
-
-  var docs = this.$__getArrayPathsToValidate();
-
-  var e2 = docs.map(function (doc) {
-    return doc.$__presaveValidate();
-  });
-  var e1 = [this.$__.saveError].concat(e2);
-  var err = e1.filter(function (x) {return x})[0];
-  this.$__.saveError = null;
-
-  return err;
-};
-
-
-/**
- * Registers an error
- *
- * @param {Error} err
- * @api private
- * @method $__error
- * @memberOf Document
- */
-
-Document.prototype.$__error = function (err) {
-  this.$__.saveError = err;
-  return this;
 };
 
 /**

--- a/lib/model.js
+++ b/lib/model.js
@@ -154,14 +154,6 @@ Model.prototype.$__preSave = function(next) {
     return next();
   }
 
-  // Check for preSave errors if we're not validating
-  if (!this.schema.options.validateBeforeSave) {
-    var preSaveErr = this.$__presaveValidate();
-    if (preSaveErr) {
-      return next(preSaveErr);
-    }
-  }
-
   // Validate
   if (this.schema.options.validateBeforeSave) {
     this.validate(next);

--- a/lib/types/embedded.js
+++ b/lib/types/embedded.js
@@ -184,7 +184,46 @@ EmbeddedDocument.prototype.invalidate = function (path, err, val, first) {
   if (first)
     this.$__.validationError = this.ownerDocument().$__.validationError;
   return true;
-}
+};
+
+/**
+ * Marks a path as valid, causing validation to succeed
+ *
+ * @param {String} path the field to mark as valid
+ * @api public
+ */
+EmbeddedDocument.prototype.$markValid = function(path) {
+  if (!this.__parent) {
+    return;
+  }
+
+  var index = this.__parentArray.indexOf(this);
+  var parentPath = this.__parentArray._path;
+  var fullPath = [parentPath, index, path].join('.');
+
+  this.__parent.$markValid(fullPath);
+};
+
+/**
+ * Checks if a path is invalid
+ *
+ * @param {String} path the field to check
+ * @api private
+ */
+
+EmbeddedDocument.prototype.$isValid = function(path) {
+  if (!this.__parent) {
+    var msg = 'Unable to invalidate a subdocument that has not been added to an array.'
+    throw new Error(msg);
+  }
+
+  var index = this.__parentArray.indexOf(this);
+  var parentPath = this.__parentArray._path;
+  var fullPath = [parentPath, index, path].join('.');
+
+  return !this.__parent.$__.validationError ||
+    !this.__parent.$__.validationError.errors[path];
+};
 
 /**
  * Returns the top level document of this sub-document.

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -1033,6 +1033,22 @@ describe('document', function(){
       }, 500);
     });
 
+    it('doesnt have stale cast errors (gh-2766)', function(done) {
+      var db = start();
+      var testSchema = new Schema({ name: String });
+      var M = db.model('gh2766', testSchema);
+
+      var m = new M({ _id: 'this is not a valid _id' });
+      assert.ok(!m.$isValid('_id'));
+      m._id = '000000000000000000000001';
+      assert.ok(m.$isValid('_id'));
+      m.validate(function(error) {
+        assert.ifError(error);
+        db.close(done);
+
+      });
+    });
+
     it('returns a promise when there are no validators', function(done) {
       var db = start();
       var schema = null;

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -856,8 +856,7 @@ describe('Model', function(){
         , BlogPost = db.model('BlogPost', collection)
         , threw = false;
 
-      var post = new BlogPost()
-      post.init({
+      var post = new BlogPost({
           title       : 'Test'
         , slug        : 'test'
         , comments    : [ { title: 'Test', date: new Date, body: 'Test' } ]
@@ -865,7 +864,7 @@ describe('Model', function(){
 
       post.get('comments')[0].set('date', 'invalid');
 
-      post.save(function(err){
+      post.save(function(err) {
         db.close();
         assert.ok(err instanceof MongooseError);
         assert.ok(err instanceof ValidationError);

--- a/test/schema.validation.test.js
+++ b/test/schema.validation.test.js
@@ -779,7 +779,7 @@ describe('schema', function(){
         assert.ok(error);
         var errorMessage = 'CastError: Cast to Object failed for value ' +
           '"waffles" at path "foods"';
-        assert.equal(errorMessage, error.toString());
+        assert.ok(error.toString().indexOf(errorMessage) !== -1, error.toString());
         done();
       });
     });


### PR DESCRIPTION
Fixes #2766 et all. Also removes the last dregs of dependency on the janky `$__.saveError` that got pulled in when merging from 3.8.x.